### PR TITLE
Use a string for import.meta.vitest

### DIFF
--- a/packages/webcrypt-session/script/build.js
+++ b/packages/webcrypt-session/script/build.js
@@ -5,7 +5,7 @@ const prefixes = ["", "adapters/trpc"];
 const shared = {
   bundle: true,
   define: {
-    "import.meta.vitest": undefined,
+    "import.meta.vitest": "undefined",
   },
 };
 prefixes.map((prefix) => {


### PR DESCRIPTION
Fix a broken build because import.meta.vitest is not a string